### PR TITLE
Fix GlobalKey crashes in WebView tabs - Resolves #35

### DIFF
--- a/lib/browser.dart
+++ b/lib/browser.dart
@@ -145,10 +145,10 @@ class _BrowserState extends State<Browser> with SingleTickerProviderStateMixin {
 
       if (isCurrentTab) {
         Future.delayed(const Duration(milliseconds: 100), () {
-          webViewTabStateKey.currentState?.onShowTab();
+          (webViewTab as WebViewTab).getState()?.onShowTab();
         });
       } else {
-        webViewTabStateKey.currentState?.onHideTab();
+        (webViewTab as WebViewTab).getState()?.onHideTab();
       }
     }
 
@@ -192,7 +192,7 @@ class _BrowserState extends State<Browser> with SingleTickerProviderStateMixin {
             body: TabViewer(
               currentIndex: browserModel.getCurrentTabIndex(),
               children: browserModel.webViewTabs.map((webViewTab) {
-                webViewTabStateKey.currentState?.pause();
+                (webViewTab as WebViewTab).getState()?.pause();
                 var screenshotData = webViewTab.webViewModel.screenshot;
                 Widget screenshotImage = Container(
                   decoration: const BoxDecoration(color: Colors.white),
@@ -225,14 +225,6 @@ class _BrowserState extends State<Browser> with SingleTickerProviderStateMixin {
                         leading: Column(
                           mainAxisAlignment: MainAxisAlignment.center,
                           children: <Widget>[
-                            // CachedNetworkImage(
-                            //   placeholder: (context, url) =>
-                            //   url == "about:blank"
-                            //       ? Container()
-                            //       : CircularProgressIndicator(),
-                            //   imageUrl: faviconUrl,
-                            //   height: 30,
-                            // )
                             CustomImage(
                                 url: faviconUrl, maxWidth: 30.0, height: 30.0)
                           ],

--- a/lib/models/browser_model.dart
+++ b/lib/models/browser_model.dart
@@ -8,6 +8,7 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter_browser/Db/hive_db_helper.dart';
 import 'package:flutter_browser/models/web_archive_model.dart';
 import 'package:flutter_browser/rss_news/models/website_list.dart';
+import 'package:flutter_browser/rss_news/services/whitelist.dart';
 import 'package:flutter_browser/rss_news/utils/debug.dart';
 import 'package:flutter_browser/rss_news/utils/show_snackbar.dart';
 import 'package:flutter_inappwebview/flutter_inappwebview.dart';
@@ -128,18 +129,14 @@ class BrowserModel extends ChangeNotifier {
   }
 
   void addTab(WebViewTab webViewTab) {
-    List<Website> websites = HiveDBHelper.getWhitelistedWebsites();
-    Set<String> whitelistDomains = websites.map((e) => e.domain).toSet();
-    // debug(whitelistDomains);
+    // Use the Whitelist.isWebsiteAllowed method for consistent validation
     if (webViewTab.webViewModel.url != null) {
-      var domain = (webViewTab.webViewModel.url!).host;
-      debug(domain);
-      if (!whitelistDomains.contains(domain)) {
+      if (!Whitelist.isWebsiteAllowed(webViewTab.webViewModel.url!)) {
         showSnackBar(message: "This website is not allowed");
         return;
       }
     }
-    webViewTab.webViewModel.url;
+    
     _homePage = true;
     _webViewTabs.add(webViewTab);
     _currentTabIndex = _webViewTabs.length - 1;
@@ -147,7 +144,6 @@ class BrowserModel extends ChangeNotifier {
     _currentWebViewModel.updateWithValue(webViewTab.webViewModel);
     notifyListeners();
   }
-
   void addTabs(List<WebViewTab> webViewTabs) {
     _homePage = true;
     for (var webViewTab in webViewTabs) {

--- a/lib/webview_tab.dart
+++ b/lib/webview_tab.dart
@@ -23,17 +23,21 @@ import 'javascript_console_result.dart';
 import 'long_press_alert_dialog.dart';
 import 'models/browser_model.dart';
 
-// check onload
-final webViewTabStateKey = GlobalKey<_WebViewTabState>();
+// Remove the global key declaration entirely
+
 
 class WebViewTab extends StatefulWidget {
   const WebViewTab({Key? key, required this.webViewModel}) : super(key: key);
 
   final WebViewModel webViewModel;
+  
+  // Add a method to access the state
+  _WebViewTabState? getState() => key != null ? (key as GlobalKey<_WebViewTabState>).currentState : null;
 
   @override
   State<WebViewTab> createState() => _WebViewTabState();
 }
+
 
 class _WebViewTabState extends State<WebViewTab> with WidgetsBindingObserver {
   InAppWebViewController? _webViewController;


### PR DESCRIPTION
This PR fixes two issues:

1. Fixed the duplicate GlobalKey issue in WebViewTab by:
   * Removing the global key declaration in webview_tab.dart
   * Adding a getState() method to access state properly
   * Updating references in browser.dart to use instance-specific keys

2. Fixed the website whitelist validation in browser_model.dart:
   * Updated the addTab method to use Whitelist.isWebsiteAllowed consistently